### PR TITLE
Fix for Android mobile browsers: soft keyboards do not send key events except for ENTER so we just take the last line from textarea without the prompt prefix + fix for iOS mobile browsers: soft keyboard did not show on some iOS versions

### DIFF
--- a/src/terminal.js
+++ b/src/terminal.js
@@ -42,6 +42,7 @@ const createElement = root => {
   el.value = '';
 
   root.appendChild(el);
+  document.body.ontouchend = function() { el.focus(); };
 
   return el;
 };

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -128,7 +128,7 @@ const executor = commands => (cmd, ...args) => cb => {
 };
 
 // Handle keyboard events
-const keyboard = (parse) => {
+const keyboard = ($element, prompt, parse) => {
   let input = [];
   const keys = {8: 'backspace', 13: 'enter'};
   const ignoreKey = code => code >= 33 && code <= 40;
@@ -138,7 +138,7 @@ const keyboard = (parse) => {
     keypress: (ev) => {
       if (key(ev) === 'enter') {
         const str = input.join('').trim();
-        parse(str);
+        parse(str || $element.value.split(/\n/)[$element.value.split(/\n/).length - 1].replace(prompt(), ''));
         input = [];
       } else if (key(ev) !== 'backspace') {
         input.push(String.fromCharCode(ev.which || ev.keyCode));
@@ -190,7 +190,7 @@ export const terminal = (opts) => {
   const render = renderer(tickrate, onrender);
   const parse = parser(onparsed);
   const focus = () => setTimeout(() => $element.focus(), 1);
-  const kbd = keyboard(parse);
+  const kbd = keyboard($element, prompt, parse);
   const clear = () => ($element.value = '');
   const input = ev => busy
     ? ev.preventDefault()


### PR DESCRIPTION
Note: Still having trouble on some iOS versions where the soft keyboard won't open at all but since I don't own any iOS device, it's hard to test. Will be trying using iOS 12 demo at https://appetize.io/demo